### PR TITLE
use cygstart instead of start on cygwin rt85972

### DIFF
--- a/lib/Browser/Open.pm
+++ b/lib/Browser/Open.pm
@@ -19,7 +19,7 @@ use parent 'Exporter';
 my @known_commands = (
   ['', $ENV{BROWSER}],
   ['darwin',  '/usr/bin/open', 1],
-  ['cygwin',  'start'],
+  ['cygwin',  'cygstart'],
   ['MSWin32', 'start', undef, 1],
   ['solaris', 'xdg-open'],
   ['solaris', 'firefox'],


### PR DESCRIPTION
This fixes rt#85972 and makes this module work on cygwin where it currently does not work.